### PR TITLE
remove unused import of `static_length`

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -13,4 +13,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia -e 'using CompatHelper; CompatHelper.main()'
+        run: julia -e 'using CompatHelper; CompatHelper.main(; subdirs=["", "test"])'

--- a/src/StrideArrays.jl
+++ b/src/StrideArrays.jl
@@ -28,7 +28,6 @@ using ArrayInterface:
   strides,
   offsets,
   indices,
-  static_length,
   axes,
   dense_dims,
   stride_rank,

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -8,4 +8,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = "0.6"
-ArrayInterface = "6"
+ArrayInterface = "7"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -4,3 +4,7 @@ ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+Aqua = "0.6"
+ArrayInterface = "6"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,8 @@ const START_TIME = time()
     StrideArrays,
     ambiguities = false,
     project_toml_formatting = false,
-    deps_compat = VERSION <= v"1.8" || isempty(VERSION.prerelease)
+    deps_compat = VERSION <= v"1.8" || isempty(VERSION.prerelease),
+    piracy = false
   )
   # Currently, there are five method ambiguities:
   # (rand!(A::AbstractStrideArray, args::Vararg{Any, K}) where K in StrideArrays at StrideArrays/src/rand.jl:3, rand!(f::F, rng::VectorizedRNG.AbstractVRNG, x::AbstractArray{T}, α::Number, β, γ) where {T<:Union{Float32, Float64}, F} in VectorizedRNG at VectorizedRNG/L3orR/src/api.jl:242)


### PR DESCRIPTION
I couldn't find any reference to `static_length` in StrideArrays.jl. Thus, I removed it to prepare for the update to ArrayInterface.jl v7.