### PR TITLE
Fix broadcasting rules given upstream broadcasting fixes

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -7,6 +7,8 @@ _extract(_) = nothing
 abstract type AbstractStrideStyle{S,N} <: Base.Broadcast.AbstractArrayStyle{N} end
 struct LinearStyle{S,N,R} <: AbstractStrideStyle{S,N} end
 struct CartesianStyle{S,N} <: AbstractStrideStyle{S,N} end
+LinearStyle{S,N,R}(::Val{N}) where {S,N,R} = LinearStyle{S,N,R}()
+CartesianStyle{S,N}(::Val{N}) where {S,N} = CartesianStyle{S,N}()
 @generated function Base.BroadcastStyle(
   ::Type{A}
 ) where {T<:VectorizationBase.NativeTypes,N,R,S,X,A<:AbstractStrideArray{T,N,R,S,X}}


### PR DESCRIPTION
There was a bug in Julia broadcasting rules fixed by https://github.com/JuliaLang/julia/pull/35948, but that fix breaks a test here, since this package was inadvertantly relying on the old incorrect logic. This fixes this package, basically correctly implements the API, and doesn't break it on current Julia versions either.